### PR TITLE
Remove typo in delete_from example

### DIFF
--- a/dynamicsax2012-msdn/while-select-statements.md
+++ b/dynamicsax2012-msdn/while-select-statements.md
@@ -133,7 +133,7 @@ You can economize your X++ statements and achieve the same effect using the [del
 ```X++  
 {   
    TableName myXrec;   
-   delete\_from myXrec   
+   delete_from myXrec   
      where  Conditions ;   
  }
 ```


### PR DESCRIPTION
Remove the extra slash that was in the delete_from code example.