### PR TITLE
Fix breadcrumbs

### DIFF
--- a/dynamicsax2012-msdn/breadcrumb/toc.yml
+++ b/dynamicsax2012-msdn/breadcrumb/toc.yml
@@ -1,6 +1,6 @@
 - name: Dynamics 365
   tocHref: /dynamicsax-2012/
-  topicHref: /landingpage/index
+  topicHref: /dynamics365/index
   items:
   - name: Dynamics AX 2012
     tocHref: /dynamicsax-2012/developer/

--- a/dynamicsax2012-msdn/breadcrumb/toc.yml
+++ b/dynamicsax2012-msdn/breadcrumb/toc.yml
@@ -1,1 +1,7 @@
-[]
+- name: Dynamics 365
+  tocHref: /dynamicsax-2012/
+  topicHref: /landingpage/index
+  items:
+  - name: Dynamics AX 2012
+    tocHref: /dynamicsax-2012/developer/
+    topicHref: /dynamicsax-2012/developer/index

--- a/dynamicsax2012-msdn/docfx.json
+++ b/dynamicsax2012-msdn/docfx.json
@@ -45,7 +45,6 @@
     ],
     "globalMetadata": {
       "breadcrumb_path": "/dynamicsax-2012/developer/breadcrumb/toc.json",
-      "extendBreadcrumb": true,
       "ROBOTS": "INDEX,FOLLOW",
       "is_archived": false,
       "ms.date": "06/03/2018",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 